### PR TITLE
Scrolls are removed from the game.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,8 +14,8 @@ allprojects {
         appName = 'Streamlined Pixel Dungeon'
         appPackageName = 'com.streamlinedpixel.streamlinedpixeldungeon'
 
-        appVersionCode = 879
-        appVersionName = '879'
+        appVersionCode = 880
+        appVersionName = String.valueOf(appVersionCode)
 
         appJavaCompatibility = JavaVersion.VERSION_11
 

--- a/core/src/main/assets/messages/actors/actors.properties
+++ b/core/src/main/assets/messages/actors/actors.properties
@@ -806,7 +806,7 @@ actors.hero.heroclass.warrior_unlock=The Warrior is automatically unlocked.
 actors.hero.heroclass.mage=mage
 actors.hero.heroclass.mage_desc_short=The Mage is an arcane expert and carries a _magical staff_ that's stronger than a wand. The staff can be _imbued with any wand_ the Mage finds.
 actors.hero.heroclass.mage_desc=The Mage starts with a _unique staff_, which recharges significantly faster than a wand and has 1 more charge. The staff _can be imbued with any wand_ the Mage finds in the dungeon.\n\nThe Mage also starts with a _wand of magic missile_ imbued in his staff, cloth armor, a waterskin, and a velvet pouch.
-actors.hero.heroclass.mage_unlock=To unlock the Mage _use a scroll of identify three times in a single run._
+actors.hero.heroclass.mage_unlock=To unlock the Mage _use a wand ten times in a single run._
 
 actors.hero.heroclass.rogue=rogue
 actors.hero.heroclass.rogue_desc_short=The Rogue can evade enemies and strike from invisibility using his _cloak of shadows._ He also _detects secrets and traps_ from a greater distance.

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/Badges.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/Badges.java
@@ -964,7 +964,7 @@ public class Badges {
 	}
 	
 	public static void validateMageUnlock(){
-		if (Statistics.scrollsOfIdentifyUsed >= 3 && !isUnlocked(Badge.UNLOCK_MAGE)){
+		if (Statistics.wandUses >= 10 && !isUnlocked(Badge.UNLOCK_MAGE)){
 			displayBadge( Badge.UNLOCK_MAGE );
 		}
 	}

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/Statistics.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/Statistics.java
@@ -61,7 +61,7 @@ public class Statistics {
 	public static int upgradesUsed;
 	public static int sneakAttacks;
 	public static int thrownAttacks;
-
+	public static int wandUses;
 	public static int spawnersAlive;
 	
 	public static float duration;

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/hero/HeroClass.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/hero/HeroClass.java
@@ -52,7 +52,6 @@ import com.shatteredpixel.shatteredpixeldungeon.items.artifacts.CloakOfShadows;
 import com.shatteredpixel.shatteredpixeldungeon.items.artifacts.HolyTome;
 import com.shatteredpixel.shatteredpixeldungeon.items.bags.MagicalHolster;
 import com.shatteredpixel.shatteredpixeldungeon.items.bags.PotionBandolier;
-import com.shatteredpixel.shatteredpixeldungeon.items.bags.ScrollHolder;
 import com.shatteredpixel.shatteredpixeldungeon.items.bags.VelvetPouch;
 import com.shatteredpixel.shatteredpixeldungeon.items.wands.WandOfMagicMissile;
 import com.shatteredpixel.shatteredpixeldungeon.items.weapon.SpiritBow;
@@ -95,18 +94,12 @@ public enum HeroClass {
 
 		new VelvetPouch().collect();
 		Dungeon.LimitedDrops.VELVET_POUCH.drop();
-		new ScrollHolder().collect();
-		Dungeon.LimitedDrops.SCROLL_HOLDER.drop();
 		new PotionBandolier().collect();
 		Dungeon.LimitedDrops.POTION_BANDOLIER.drop();
 		new MagicalHolster().collect();
 		Dungeon.LimitedDrops.MAGICAL_HOLSTER.drop();
 
-		// Let's make all scrolls known right away
-		for (var scroll : Generator.Category.SCROLL.classes) {
-			((Item) Reflection.newInstance(scroll)).identify();
-		}
-
+		// Let's make all potions known right away
 		for (var potion : Generator.Category.POTION.classes) {
 			((Item) Reflection.newInstance(potion)).identify();
 		}

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/DM100.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/DM100.java
@@ -50,7 +50,7 @@ public class DM100 extends Mob implements Callback {
 		EXP = 6;
 		maxLvl = 13;
 		
-		loot = Generator.Category.SCROLL;
+		loot = Generator.Category.POTION;
 		lootChance = 0.25f;
 		
 		properties.add(Property.ELECTRIC);

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/Mob.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/Mob.java
@@ -85,6 +85,7 @@ import com.shatteredpixel.shatteredpixeldungeon.journal.Notes;
 import com.shatteredpixel.shatteredpixeldungeon.levels.Level;
 import com.shatteredpixel.shatteredpixeldungeon.levels.features.Chasm;
 import com.shatteredpixel.shatteredpixeldungeon.levels.traps.Trap;
+import com.shatteredpixel.shatteredpixeldungeon.mechanics.Ballistica;
 import com.shatteredpixel.shatteredpixeldungeon.messages.Messages;
 import com.shatteredpixel.shatteredpixeldungeon.plants.Swiftthistle;
 import com.shatteredpixel.shatteredpixeldungeon.scenes.GameScene;
@@ -706,7 +707,7 @@ public abstract class Mob extends Char {
 			Statistics.thrownAttacks++;
 			Badges.validateHuntressUnlock();
 		}
-		
+
 		if (surprisedBy(enemy)) {
 			Statistics.sneakAttacks++;
 			Badges.validateRogueUnlock();

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/Succubus.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/actors/mobs/Succubus.java
@@ -33,6 +33,8 @@ import com.shatteredpixel.shatteredpixeldungeon.effects.FloatingText;
 import com.shatteredpixel.shatteredpixeldungeon.effects.Speck;
 import com.shatteredpixel.shatteredpixeldungeon.items.Generator;
 import com.shatteredpixel.shatteredpixeldungeon.items.Item;
+import com.shatteredpixel.shatteredpixeldungeon.items.potions.Potion;
+import com.shatteredpixel.shatteredpixeldungeon.items.potions.PotionOfStrength;
 import com.shatteredpixel.shatteredpixeldungeon.items.scrolls.Scroll;
 import com.shatteredpixel.shatteredpixeldungeon.items.scrolls.ScrollOfIdentify;
 import com.shatteredpixel.shatteredpixeldungeon.items.scrolls.ScrollOfTeleportation;
@@ -62,7 +64,7 @@ public class Succubus extends Mob {
 		EXP = 12;
 		maxLvl = 25;
 		
-		loot = Generator.Category.SCROLL;
+		loot = Generator.Category.POTION;
 		lootChance = 0.33f;
 
 		properties.add(Property.DEMONIC);
@@ -171,10 +173,10 @@ public class Succubus extends Mob {
 
 	@Override
 	public Item createLoot() {
-		Class<?extends Scroll> loot;
+		Class<?extends Potion> loot;
 		do{
-			loot = (Class<? extends Scroll>) Random.oneOf(Generator.Category.SCROLL.classes);
-		} while (loot == ScrollOfIdentify.class || loot == ScrollOfUpgrade.class);
+			loot = (Class<? extends Potion>) Random.oneOf(Generator.Category.POTION.classes);
+		} while (loot == PotionOfStrength.class);
 
 		return Reflection.newInstance(loot);
 	}

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/EquipableItem.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/EquipableItem.java
@@ -123,12 +123,12 @@ public abstract class EquipableItem extends Item {
 
 	public boolean doUnequip( Hero hero, boolean collect, boolean single ) {
 
-		if (cursed
-				&& hero.buff(MagicImmune.class) == null
-				&& (!hero.belongings.lostInventory() || keptThroughLostInventory())) {
-			GLog.w(Messages.get(EquipableItem.class, "unequip_cursed"));
-			return false;
-		}
+//		if (cursed
+//				&& hero.buff(MagicImmune.class) == null
+//				&& (!hero.belongings.lostInventory() || keptThroughLostInventory())) {
+//			GLog.w(Messages.get(EquipableItem.class, "unequip_cursed"));
+//			return false;
+//		}
 
 		if (single) {
 			hero.spendAndNext( timeToEquip( hero ) );

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/Generator.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/Generator.java
@@ -237,7 +237,7 @@ public class Generator {
 		POTION	( 8, 8, Potion.class ),
 		SEED	( 1, 1, Plant.Seed.class ),
 		
-		SCROLL	( 8, 8, Scroll.class ),
+//		SCROLL	( 8, 8, Scroll.class ),
 		STONE   ( 1, 1, Runestone.class),
 		
 		GOLD	( 10, 10,   Gold.class );
@@ -284,7 +284,6 @@ public class Generator {
 			subOrderings.put(Trinket.class, new ArrayList<>(Arrays.asList(Trinket.class, TrinketCatalyst.class)));
 			subOrderings.put(MissileWeapon.class, new ArrayList<>(Arrays.asList(MissileWeapon.class, Bomb.class)));
 			subOrderings.put(Potion.class, new ArrayList<>(Arrays.asList(Potion.class, ExoticPotion.class, Brew.class, Elixir.class, LiquidMetal.class)));
-			subOrderings.put(Scroll.class, new ArrayList<>(Arrays.asList(Scroll.class, ExoticScroll.class, Spell.class, ArcaneResin.class)));
 		}
 
 		//in case there are multiple matches, this will return the latest match
@@ -350,23 +349,23 @@ public class Generator {
 			SEED.defaultProbs = new float[]{ 0, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 1 };
 			SEED.probs = SEED.defaultProbs.clone();
 			
-			SCROLL.classes = new Class<?>[]{
-					ScrollOfIdentify.class,
-					ScrollOfRemoveCurse.class,
-					ScrollOfMirrorImage.class,
-					ScrollOfRecharging.class,
-					ScrollOfTeleportation.class,
-					ScrollOfLullaby.class,
-					ScrollOfMagicMapping.class,
-					ScrollOfRage.class,
-					ScrollOfRetribution.class,
-					ScrollOfTerror.class,
-					ScrollOfTransmutation.class
-			};
-			SCROLL.defaultProbs  = new float[]{ 3, 3, 1, 2, 1, 1, 1, 1, 1, 1, 1 };
-			SCROLL.defaultProbs2 = new float[]{ 3, 3, 2, 1, 2, 1, 1, 1, 1, 1, 0 };
-			SCROLL.probs = SCROLL.defaultProbs.clone();
-			
+//			SCROLL.classes = new Class<?>[]{
+//					ScrollOfIdentify.class,
+//					ScrollOfRemoveCurse.class,
+//					ScrollOfMirrorImage.class,
+//					ScrollOfRecharging.class,
+//					ScrollOfTeleportation.class,
+//					ScrollOfLullaby.class,
+//					ScrollOfMagicMapping.class,
+//					ScrollOfRage.class,
+//					ScrollOfRetribution.class,
+//					ScrollOfTerror.class,
+//					ScrollOfTransmutation.class
+//			};
+//			SCROLL.defaultProbs  = new float[]{ 3, 3, 1, 2, 1, 1, 1, 1, 1, 1, 1 };
+//			SCROLL.defaultProbs2 = new float[]{ 3, 3, 2, 1, 2, 1, 1, 1, 1, 1, 0 };
+//			SCROLL.probs = SCROLL.defaultProbs.clone();
+//
 			STONE.classes = new Class<?>[]{
 					StoneOfEnchantment.class,   //1 is guaranteed to drop on floors 6-19
 					StoneOfIntuition.class,     //1 additional stone is also dropped on floors 1-3
@@ -560,7 +559,7 @@ public class Generator {
 					TimekeepersHourglass.class,
 					UnstableSpellbook.class
 			};
-			ARTIFACT.defaultProbs = new float[]{ 1, 1, 0, 1, 1, 0, 1, 1, 1, 1, 1 };
+			ARTIFACT.defaultProbs = new float[]{ 1, 1, 0, 1, 1, 0, 1, 1, 1, 1, 0 };
 			ARTIFACT.probs = ARTIFACT.defaultProbs.clone();
 
 			//Trinkets are unique like artifacts, but unlike them you can only have one at once
@@ -717,10 +716,6 @@ public class Generator {
 					if (Random.Float() < ExoticCrystals.consumableExoticChance()){
 						itemCls = ExoticPotion.regToExo.get(itemCls);
 					}
-				} else if (ExoticScroll.regToExo.containsKey(itemCls)){
-					if (Random.Float() < ExoticCrystals.consumableExoticChance()){
-						itemCls = ExoticScroll.regToExo.get(itemCls);
-					}
 				}
 
 				return ((Item) Reflection.newInstance(itemCls)).random();
@@ -744,10 +739,6 @@ public class Generator {
 			if (ExoticPotion.regToExo.containsKey(itemCls)){
 				if (Random.Float() < ExoticCrystals.consumableExoticChance()){
 					itemCls = ExoticPotion.regToExo.get(itemCls);
-				}
-			} else if (ExoticScroll.regToExo.containsKey(itemCls)){
-				if (Random.Float() < ExoticCrystals.consumableExoticChance()){
-					itemCls = ExoticScroll.regToExo.get(itemCls);
 				}
 			}
 

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/Item.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/Item.java
@@ -82,10 +82,10 @@ public class Item implements Bundlable {
 	
 	private int level = 0;
 
-	public boolean levelKnown = false;
+	public boolean levelKnown = true;
 	
 	public boolean cursed;
-	public boolean cursedKnown;
+	public boolean cursedKnown = true;
 	
 	// Unique items persist through revival
 	public boolean unique = false;

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/artifacts/UnstableSpellbook.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/artifacts/UnstableSpellbook.java
@@ -90,18 +90,6 @@ public class UnstableSpellbook extends Artifact {
 
 	private void setupScrolls(){
 		scrolls.clear();
-
-		Class<?>[] scrollClasses = Generator.Category.SCROLL.classes;
-		float[] probs = Generator.Category.SCROLL.defaultProbsTotal.clone(); //array of primitives, clone gives deep copy.
-		int i = Random.chances(probs);
-
-		while (i != -1){
-			scrolls.add(scrollClasses[i]);
-			probs[i] = 0;
-
-			i = Random.chances(probs);
-		}
-		scrolls.remove(ScrollOfTransmutation.class);
 	}
 
 	@Override
@@ -139,68 +127,6 @@ public class UnstableSpellbook extends Artifact {
 	}
 
 	public void doReadEffect(Hero hero){
-		charge--;
-
-		Scroll scroll;
-		do {
-			scroll = (Scroll) Generator.randomUsingDefaults(Generator.Category.SCROLL);
-		} while (scroll == null
-				//reduce the frequency of these scrolls by half
-				||((scroll instanceof ScrollOfIdentify ||
-				scroll instanceof ScrollOfRemoveCurse ||
-				scroll instanceof ScrollOfMagicMapping) && Random.Int(2) == 0)
-				//cannot roll transmutation
-				|| (scroll instanceof ScrollOfTransmutation));
-
-		scroll.anonymize();
-		curItem = scroll;
-		curUser = hero;
-
-		//if there are charges left and the scroll has been given to the book
-		if (charge > 0 && !scrolls.contains(scroll.getClass())) {
-			final Scroll fScroll = scroll;
-
-			final ExploitHandler handler = Buff.affect(hero, ExploitHandler.class);
-			handler.scroll = scroll;
-
-			GameScene.show(new WndOptions(new ItemSprite(this),
-					Messages.get(this, "prompt"),
-					Messages.get(this, "read_empowered"),
-					scroll.trueName(),
-					Messages.get(ExoticScroll.regToExo.get(scroll.getClass()), "name")){
-				@Override
-				protected void onSelect(int index) {
-					handler.detach();
-					if (index == 1){
-						Scroll scroll = Reflection.newInstance(ExoticScroll.regToExo.get(fScroll.getClass()));
-						curItem = scroll;
-						charge--;
-						scroll.anonymize();
-						checkForArtifactProc(curUser, scroll);
-						scroll.doRead();
-						Invisibility.dispel();
-						Talent.onArtifactUsed(Dungeon.hero);
-					} else {
-						checkForArtifactProc(curUser, fScroll);
-						fScroll.doRead();
-						Invisibility.dispel();
-						Talent.onArtifactUsed(Dungeon.hero);
-					}
-					updateQuickslot();
-				}
-
-				@Override
-				public void onBackPressed() {
-					//do nothing
-				}
-			});
-		} else {
-			checkForArtifactProc(curUser, scroll);
-			scroll.doRead();
-			Invisibility.dispel();
-			Talent.onArtifactUsed(Dungeon.hero);
-		}
-
 		updateQuickslot();
 	}
 

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/rings/Ring.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/rings/Ring.java
@@ -152,7 +152,7 @@ public class Ring extends KindofMisc {
 	}
 	
 	public boolean isKnown() {
-		return anonymous || (handler != null && handler.isKnown( this ));
+		return true;
 	}
 	
 	public void setKnown() {
@@ -234,12 +234,7 @@ public class Ring extends KindofMisc {
 		
 		return this;
 	}
-	
-	@Override
-	public boolean isIdentified() {
-		return super.isIdentified() && isKnown();
-	}
-	
+
 	@Override
 	public Item identify( boolean byHero ) {
 		setKnown();

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/rings/RingOfWealth.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/rings/RingOfWealth.java
@@ -208,7 +208,7 @@ public class RingOfWealth extends Ring {
 	}
 
 	private static Item genLowValueConsumable(){
-		switch (Random.Int(4)){
+		switch (Random.Int(3)){
 			case 0: default:
 				Item i = new Gold().random();
 				return i.quantity(i.quantity()/2);
@@ -216,13 +216,11 @@ public class RingOfWealth extends Ring {
 				return Generator.randomUsingDefaults(Generator.Category.STONE);
 			case 2:
 				return Generator.randomUsingDefaults(Generator.Category.POTION);
-			case 3:
-				return Generator.randomUsingDefaults(Generator.Category.SCROLL);
 		}
 	}
 
 	private static Item genMidValueConsumable(){
-		switch (Random.Int(6)){
+		switch (Random.Int(5)){
 			case 0: default:
 				Item i = genLowValueConsumable();
 				return i.quantity(i.quantity()*2);
@@ -234,23 +232,16 @@ public class RingOfWealth extends Ring {
 					return Reflection.newInstance(i.getClass());
 				}
 			case 2:
-				i = Generator.randomUsingDefaults(Generator.Category.SCROLL);
-				if (!(i instanceof ExoticScroll)){
-					return Reflection.newInstance(ExoticScroll.regToExo.get(i.getClass()));
-				} else {
-					return Reflection.newInstance(i.getClass());
-				}
-			case 3:
 				return Random.Int(2) == 0 ? new UnstableBrew() : new UnstableSpell();
-			case 4:
+			case 3:
 				return new Bomb();
-			case 5:
+			case 4:
 				return new Honeypot();
 		}
 	}
 
 	private static Item genHighValueConsumable(){
-		switch (Random.Int(4)){
+		switch (Random.Int(3)){
 			case 0: default:
 				Item i = genMidValueConsumable();
 				if (i instanceof Bomb){
@@ -262,8 +253,6 @@ public class RingOfWealth extends Ring {
 				return new StoneOfEnchantment();
 			case 2:
 				return Random.Float() < ExoticCrystals.consumableExoticChance() ? new PotionOfDivineInspiration() : new PotionOfExperience();
-			case 3:
-				return Random.Float() < ExoticCrystals.consumableExoticChance() ? new ScrollOfMetamorphosis() : new ScrollOfTransmutation();
 		}
 	}
 

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/scrolls/Scroll.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/scrolls/Scroll.java
@@ -86,6 +86,20 @@ public abstract class Scroll extends Item {
 			put("TIWAZ",ItemSpriteSheet.SCROLL_TIWAZ);
 		}
 	};
+
+	private static final Class<? extends Scroll>[] scrollClasses = new Class[]{
+		ScrollOfIdentify.class,
+				ScrollOfRemoveCurse.class,
+				ScrollOfMirrorImage.class,
+				ScrollOfRecharging.class,
+				ScrollOfTeleportation.class,
+				ScrollOfLullaby.class,
+				ScrollOfMagicMapping.class,
+				ScrollOfRage.class,
+				ScrollOfRetribution.class,
+				ScrollOfTerror.class,
+				ScrollOfTransmutation.class
+	};
 	
 	protected static ItemStatusHandler<Scroll> handler;
 	
@@ -103,7 +117,7 @@ public abstract class Scroll extends Item {
 	
 	@SuppressWarnings("unchecked")
 	public static void initLabels() {
-		handler = new ItemStatusHandler<>( (Class<? extends Scroll>[])Generator.Category.SCROLL.classes, runes );
+		handler = new ItemStatusHandler<>(scrollClasses, runes );
 	}
 
 	public static void clearLabels(){
@@ -132,7 +146,7 @@ public abstract class Scroll extends Item {
 
 	@SuppressWarnings("unchecked")
 	public static void restore( Bundle bundle ) {
-		handler = new ItemStatusHandler<>( (Class<? extends Scroll>[])Generator.Category.SCROLL.classes, runes, bundle );
+		handler = new ItemStatusHandler<>(scrollClasses, runes, bundle );
 	}
 	
 	public Scroll() {
@@ -272,7 +286,7 @@ public abstract class Scroll extends Item {
 	}
 	
 	public static boolean allKnown() {
-		return handler != null && handler.known().size() == Generator.Category.SCROLL.classes.length;
+		return handler != null && handler.known().size() == scrollClasses.length;
 	}
 	
 	@Override

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/spells/Recycle.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/spells/Recycle.java
@@ -69,11 +69,6 @@ public class Recycle extends InventorySpell {
 				if (item instanceof ExoticPotion){
 					result = Reflection.newInstance(ExoticPotion.regToExo.get(result.getClass()));
 				}
-			} else if (item instanceof Scroll) {
-				result = Generator.randomUsingDefaults(Generator.Category.SCROLL);
-				if (item instanceof ExoticScroll){
-					result = Reflection.newInstance(ExoticScroll.regToExo.get(result.getClass()));
-				}
 			} else if (item instanceof Plant.Seed) {
 				result = Generator.randomUsingDefaults(Generator.Category.SEED);
 			} else if (item instanceof Runestone) {

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/wands/Wand.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/items/wands/Wand.java
@@ -24,6 +24,7 @@ package com.shatteredpixel.shatteredpixeldungeon.items.wands;
 import com.shatteredpixel.shatteredpixeldungeon.Assets;
 import com.shatteredpixel.shatteredpixeldungeon.Badges;
 import com.shatteredpixel.shatteredpixeldungeon.Dungeon;
+import com.shatteredpixel.shatteredpixeldungeon.Statistics;
 import com.shatteredpixel.shatteredpixeldungeon.actors.Actor;
 import com.shatteredpixel.shatteredpixeldungeon.actors.Char;
 import com.shatteredpixel.shatteredpixeldungeon.actors.buffs.Barrier;
@@ -455,6 +456,8 @@ public abstract class Wand extends Item {
 	}
 
 	public void wandUsed() {
+		Statistics.wandUses++;
+		Badges.validateMageUnlock();
 		if (!isIdentified()) {
 			float uses = Math.min( availableUsesToID, Talent.itemIDSpeedFactor(Dungeon.hero, this) );
 			availableUsesToID -= uses;

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/journal/Catalog.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/journal/Catalog.java
@@ -222,8 +222,6 @@ public enum Catalog {
 
 		POTIONS.addItems(Generator.Category.POTION.classes);
 
-		SCROLLS.addItems(Generator.Category.SCROLL.classes);
-
 		SEEDS.addItems(Generator.Category.SEED.classes);
 
 		STONES.addItems(Generator.Category.STONE.classes);

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/levels/rooms/special/CrystalChoiceRoom.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/levels/rooms/special/CrystalChoiceRoom.java
@@ -106,7 +106,7 @@ public class CrystalChoiceRoom extends SpecialRoom {
 		for (int i = 0; i < n; i++){
 			Item reward = Generator.random(Random.oneOf(
 					Generator.Category.POTION,
-					Generator.Category.SCROLL
+					Generator.Category.POTION
 			));
 			int pos;
 			do {

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/levels/rooms/special/CrystalPathRoom.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/levels/rooms/special/CrystalPathRoom.java
@@ -168,19 +168,14 @@ public class CrystalPathRoom extends SpecialRoom {
 
 		ArrayList<Item> duplicates = new ArrayList<>();
 
-		if (Random.Int(2) == 0){
-			addRewardItem(Generator.Category.POTION, potions, duplicates);
-			scrolls.add(Random.Float() < ExoticCrystals.consumableExoticChance()
-					? new ScrollOfMetamorphosis() : new ScrollOfTransmutation());
-		} else {
-			potions.add(Random.Float() < ExoticCrystals.consumableExoticChance()
-					? new PotionOfDivineInspiration() : new PotionOfExperience());
-			addRewardItem(Generator.Category.SCROLL, scrolls, duplicates);
-		}
+
+		potions.add(Random.Float() < ExoticCrystals.consumableExoticChance()
+				? new PotionOfDivineInspiration() : new PotionOfExperience());
+		addRewardItem(Generator.Category.POTION, scrolls, duplicates);
 		addRewardItem(Generator.Category.POTION, potions, duplicates);
-		addRewardItem(Generator.Category.SCROLL, scrolls, duplicates);
+		addRewardItem(Generator.Category.POTION, scrolls, duplicates);
 		addRewardItem(Generator.Category.POTION, potions, duplicates);
-		addRewardItem(Generator.Category.SCROLL, scrolls, duplicates);
+		addRewardItem(Generator.Category.POTION, scrolls, duplicates);
 
 		//need to undo the changes to spawn chances that the duplicates created
 		for (Item i : duplicates){
@@ -223,9 +218,9 @@ public class CrystalPathRoom extends SpecialRoom {
 				if (b instanceof ExoticScroll){
 					bCls = ExoticScroll.exoToReg.get(bCls);
 				}
-				for (int i = 0; i < Generator.Category.SCROLL.classes.length; i++){
-					if (aCls == Generator.Category.SCROLL.classes[i]) aVal = (int)Generator.Category.SCROLL.defaultProbsTotal[i];
-					if (bCls == Generator.Category.SCROLL.classes[i]) bVal = (int)Generator.Category.SCROLL.defaultProbsTotal[i];
+				for (int i = 0; i < Generator.Category.POTION.classes.length; i++){
+					if (aCls == Generator.Category.POTION.classes[i]) aVal = (int)Generator.Category.POTION.defaultProbsTotal[i];
+					if (bCls == Generator.Category.POTION.classes[i]) bVal = (int)Generator.Category.POTION.defaultProbsTotal[i];
 				}
 				return bVal - aVal;
 			}

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/levels/rooms/special/LibraryRoom.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/levels/rooms/special/LibraryRoom.java
@@ -52,12 +52,7 @@ public class LibraryRoom extends SpecialRoom {
 			do {
 				pos = level.pointToCell(random());
 			} while (level.map[pos] != Terrain.EMPTY_SP || level.heaps.get( pos ) != null);
-			Item item;
-			if (i == 0)
-				item = Random.Int(2) == 0 ? new ScrollOfIdentify() : new ScrollOfRemoveCurse();
-			else
-				item = prize( level );
-			level.drop( item, pos );
+			level.drop( prize( level ), pos );
 		}
 		
 		entrance.set( Door.Type.LOCKED );
@@ -71,7 +66,7 @@ public class LibraryRoom extends SpecialRoom {
 		if (prize == null){
 			prize = level.findPrizeItem( Scroll.class );
 			if (prize == null) {
-				prize = Generator.random( Generator.Category.SCROLL );
+				prize = Generator.random( Generator.Category.POTION );
 			}
 		}
 		

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/levels/rooms/special/PitRoom.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/levels/rooms/special/PitRoom.java
@@ -97,7 +97,6 @@ public class PitRoom extends SpecialRoom {
 	private static Item prize( Level level ) {
 		return Generator.random( Random.oneOf(
 			Generator.Category.POTION,
-			Generator.Category.SCROLL,
 			Generator.Category.GOLD
 		) );
 	}

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/levels/rooms/special/ShopRoom.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/levels/rooms/special/ShopRoom.java
@@ -46,9 +46,6 @@ import com.shatteredpixel.shatteredpixeldungeon.items.bags.VelvetPouch;
 import com.shatteredpixel.shatteredpixeldungeon.items.bombs.Bomb;
 import com.shatteredpixel.shatteredpixeldungeon.items.food.SmallRation;
 import com.shatteredpixel.shatteredpixeldungeon.items.potions.PotionOfHealing;
-import com.shatteredpixel.shatteredpixeldungeon.items.scrolls.ScrollOfIdentify;
-import com.shatteredpixel.shatteredpixeldungeon.items.scrolls.ScrollOfMagicMapping;
-import com.shatteredpixel.shatteredpixeldungeon.items.scrolls.ScrollOfRemoveCurse;
 import com.shatteredpixel.shatteredpixeldungeon.items.spells.Alchemize;
 import com.shatteredpixel.shatteredpixeldungeon.items.stones.StoneOfAugmentation;
 import com.shatteredpixel.shatteredpixeldungeon.items.weapon.melee.MeleeWeapon;
@@ -278,14 +275,8 @@ public class ShopRoom extends SpecialRoom {
 		itemsToSpawn.add( Generator.randomUsingDefaults( Generator.Category.POTION ) );
 		itemsToSpawn.add( Generator.randomUsingDefaults( Generator.Category.POTION ) );
 
-		itemsToSpawn.add( new ScrollOfIdentify() );
-		itemsToSpawn.add( new ScrollOfRemoveCurse() );
-		itemsToSpawn.add( new ScrollOfMagicMapping() );
-
 		for (int i=0; i < 2; i++)
-			itemsToSpawn.add( Random.Int(2) == 0 ?
-					Generator.randomUsingDefaults( Generator.Category.POTION ) :
-					Generator.randomUsingDefaults( Generator.Category.SCROLL ) );
+			itemsToSpawn.add(Generator.randomUsingDefaults(Generator.Category.POTION));
 
 
 		itemsToSpawn.add( new SmallRation() );

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/levels/rooms/standard/RitualRoom.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/levels/rooms/standard/RitualRoom.java
@@ -106,7 +106,7 @@ public class RitualRoom extends PatchRoom {
 		Item prize = Random.Int(2) == 0 ? level.findPrizeItem() : null;
 
 		if (prize == null){
-			prize = Generator.random( Random.oneOf(Generator.Category.POTION, Generator.Category.SCROLL));
+			prize = Generator.random(Generator.Category.POTION);
 		}
 
 		level.drop(prize, level.pointToCell(p));

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/levels/rooms/standard/StudyRoom.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/levels/rooms/standard/StudyRoom.java
@@ -83,9 +83,8 @@ public class StudyRoom extends StandardRoom {
 		if (prize != null) {
 			level.drop(prize, (center.x + center.y * level.width()));
 		} else {
-			level.drop(Generator.random( Random.oneOf(
-					Generator.Category.POTION,
-					Generator.Category.SCROLL)), (center.x + center.y * level.width()));
+			level.drop(Generator.random(Generator.Category.POTION),
+					(center.x + center.y * level.width()));
 		}
 	}
 }

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/ui/CustomNoteButton.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/ui/CustomNoteButton.java
@@ -214,9 +214,6 @@ public class CustomNoteButton extends IconButton {
 			for (Class<?> potionCls : Generator.Category.POTION.classes) {
 				items.add((Item) Reflection.newInstance(potionCls));
 			}
-			for (Class<?> potionCls : Generator.Category.SCROLL.classes) {
-				items.add((Item) Reflection.newInstance(potionCls));
-			}
 			for (Class<?> potionCls : Generator.Category.RING.classes) {
 				items.add((Item) Reflection.newInstance(potionCls));
 			}

--- a/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/ui/QuickRecipe.java
+++ b/core/src/main/java/com/shatteredpixel/shatteredpixeldungeon/ui/QuickRecipe.java
@@ -279,16 +279,16 @@ public class QuickRecipe extends Component {
 					}
 				}));
 				return result;
+//			case 1:
+//				Recipe r = new Scroll.ScrollToStone();
+//				for (Class<?> cls : Generator.Category.SCROLL.classes){
+//					Scroll scroll = (Scroll) Reflection.newInstance(cls);
+//					if (!scroll.isKnown()) scroll.anonymize();
+//					ArrayList<Item> in = new ArrayList<Item>(Arrays.asList(scroll));
+//					result.add(new QuickRecipe( r, in, r.sampleOutput(in)));
+//				}
+//				return result;
 			case 1:
-				Recipe r = new Scroll.ScrollToStone();
-				for (Class<?> cls : Generator.Category.SCROLL.classes){
-					Scroll scroll = (Scroll) Reflection.newInstance(cls);
-					if (!scroll.isKnown()) scroll.anonymize();
-					ArrayList<Item> in = new ArrayList<Item>(Arrays.asList(scroll));
-					result.add(new QuickRecipe( r, in, r.sampleOutput(in)));
-				}
-				return result;
-			case 2:
 				result.add(new QuickRecipe( new StewedMeat.oneMeat() ));
 				result.add(new QuickRecipe( new StewedMeat.twoMeat() ));
 				result.add(new QuickRecipe( new StewedMeat.threeMeat() ));
@@ -311,23 +311,23 @@ public class QuickRecipe extends Component {
 							}
 						}));
 				return result;
-			case 3:
-				r = new ExoticPotion.PotionToExotic();
+			case 2:
+				Recipe r = new ExoticPotion.PotionToExotic();
 				for (Class<?> cls : Generator.Category.POTION.classes){
 					Potion pot = (Potion) Reflection.newInstance(cls);
 					ArrayList<Item> in = new ArrayList<>(Arrays.asList(pot));
 					result.add(new QuickRecipe( r, in, r.sampleOutput(in)));
 				}
 				return result;
-			case 4:
-				r = new ExoticScroll.ScrollToExotic();
-				for (Class<?> cls : Generator.Category.SCROLL.classes){
-					Scroll scroll = (Scroll) Reflection.newInstance(cls);
-					ArrayList<Item> in = new ArrayList<>(Arrays.asList(scroll));
-					result.add(new QuickRecipe( r, in, r.sampleOutput(in)));
-				}
-				return result;
-			case 5:
+//			case 3:
+//				r = new ExoticScroll.ScrollToExotic();
+//				for (Class<?> cls : Generator.Category.SCROLL.classes){
+//					Scroll scroll = (Scroll) Reflection.newInstance(cls);
+//					ArrayList<Item> in = new ArrayList<>(Arrays.asList(scroll));
+//					result.add(new QuickRecipe( r, in, r.sampleOutput(in)));
+//				}
+//				return result;
+			case 3:
 				r = new Bomb.EnhanceBomb();
 				int i = 0;
 				for (Class<?> cls : Bomb.EnhanceBomb.validIngredients.keySet()){
@@ -341,7 +341,7 @@ public class QuickRecipe extends Component {
 					i++;
 				}
 				return result;
-			case 6:
+			case 4:
 				result.add(new QuickRecipe( new LiquidMetal.Recipe(),
 						new ArrayList<Item>(Arrays.asList(new MissileWeapon.PlaceHolder())),
 						new LiquidMetal()));
@@ -349,7 +349,7 @@ public class QuickRecipe extends Component {
 						new ArrayList<Item>(Arrays.asList(new Wand.PlaceHolder())),
 						new ArcaneResin()));
 				return result;
-			case 7:
+			case 5:
 				result.add(new QuickRecipe(new UnstableBrew.Recipe(), new ArrayList<>(Arrays.asList(new Potion.PlaceHolder(), new  Plant.Seed.PlaceHolder())), new UnstableBrew()));
 				result.add(new QuickRecipe(new CausticBrew.Recipe()));
 				result.add(new QuickRecipe(new BlizzardBrew.Recipe()));
@@ -367,7 +367,7 @@ public class QuickRecipe extends Component {
 				result.add(new QuickRecipe(new ElixirOfFeatherFall.Recipe()));
 				result.add(new QuickRecipe(new ElixirOfMight.Recipe()));
 				return result;
-			case 8:
+			case 6:
 				result.add(new QuickRecipe(new UnstableSpell.Recipe(), new ArrayList<>(Arrays.asList(new Scroll.PlaceHolder(), new  Runestone.PlaceHolder())), new UnstableSpell()));
 				result.add(new QuickRecipe(new WildEnergy.Recipe()));
 				result.add(new QuickRecipe(new TelekineticGrab.Recipe()));


### PR DESCRIPTION
Scrolls are removed from the game.

Why: there are too many ways to aid one in combat (use a scroll, use a potion, use a stone, use a wand etc) which make the game cluttered but don't add much value.

Three scrolls are special so you might wander what am I doing about those?
- Scroll of upgrade - has been effectively removed in one of the previous changes.
- Scroll of identity - you don't need it now, everything is identified
- Scroll of remove curse - curses can't be removed normally anymore, but at the same time, cursed items can be taken off freely. 

Mage is unlocked now by using a wand which makes much more sense anyway if you ask me.